### PR TITLE
Bumped maximum node version to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "strapi-migrations-data"
   ],
   "engines": {
-    "node": ">=12.x.x <=16.x.x",
+    "node": ">=12.x.x <=18.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
This plugin seems to work properly with node 18, so this PR restores compatibility to current versions of strapi.
Fixes https://github.com/TonyDeplanque/strapi-plugin-migrations/issues/12